### PR TITLE
test: add Playwright end-to-end browser tests

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -62,8 +62,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -75,7 +75,7 @@ jobs:
         run: npm run e2e
       - name: upload Playwright report
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: playwright-report/

--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -53,3 +53,30 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+  # End-to-end tests run in a real browser against the Vite dev server, which
+  # Playwright starts and stops itself (see playwright.config.ts). Runs
+  # independently of the build/deploy job.
+  e2e:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - name: install dependencies
+        run: npm ci
+      - name: install Playwright browser
+        run: npx playwright install --with-deps chromium
+      - name: run e2e tests
+        run: npm run e2e
+      - name: upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,8 @@ dist-ssr
 *.sln
 *.sw?
 coverage
+
+# Playwright
+/test-results/
+/playwright-report/
+/playwright/.cache/

--- a/e2e/calendar.spec.ts
+++ b/e2e/calendar.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test';
+import { gotoApp, positiveBtn, dayCell, dayCircle, TODAY } from './helpers';
+
+test.describe('calendar', () => {
+  test.beforeEach(async ({ page }) => {
+    await gotoApp(page);
+  });
+
+  test('highlights today', async ({ page }) => {
+    await expect(dayCircle(page, TODAY)).toHaveClass(/ring-blue-500/);
+  });
+
+  test('reflects a completed day with the positive color', async ({ page }) => {
+    await positiveBtn(page).click();
+    await expect(dayCircle(page, TODAY)).toHaveClass(/bg-cyan-500/);
+  });
+
+  test('does not allow selecting a future day', async ({ page }) => {
+    const future = dayCell(page, '2025-06-20');
+    await expect(future).toHaveClass(/cursor-default/);
+    await future.click(); // no-op: future days are not clickable
+    await expect(page.getByRole('heading', { name: 'Today' })).toBeVisible();
+  });
+
+  test('navigates between months', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'June 2025' })).toBeVisible();
+
+    await page.getByRole('button', { name: '→' }).click();
+    await expect(page.getByRole('heading', { name: 'July 2025' })).toBeVisible();
+
+    await page.getByRole('button', { name: '←' }).click();
+    await page.getByRole('button', { name: '←' }).click();
+    await expect(page.getByRole('heading', { name: 'May 2025' })).toBeVisible();
+  });
+});

--- a/e2e/daily-action.spec.ts
+++ b/e2e/daily-action.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test';
+import { gotoApp, positiveBtn, negativeBtn, noteBox, statValue, TODAY } from './helpers';
+
+test.describe('daily action', () => {
+  test.beforeEach(async ({ page }) => {
+    await gotoApp(page);
+  });
+
+  test('marks today completed, then clears it on a second click', async ({ page }) => {
+    await expect(statValue(page, 'Success Rate')).toHaveText('0%');
+
+    await positiveBtn(page).click();
+    await expect(positiveBtn(page)).toHaveClass(/bg-cyan-500/);
+    await expect(statValue(page, 'Success Rate')).toHaveText('100%');
+    await expect(page.locator('.all-time-rate')).toHaveText('100%');
+
+    // Clicking the active status again clears it back to untracked.
+    await positiveBtn(page).click();
+    await expect(positiveBtn(page)).not.toHaveClass(/bg-cyan-500/);
+    await expect(statValue(page, 'Success Rate')).toHaveText('0%');
+  });
+
+  test('marking negative counts as tracked but not completed', async ({ page }) => {
+    await negativeBtn(page).click();
+    await expect(negativeBtn(page)).toHaveClass(/bg-red-500/);
+    await expect(statValue(page, 'Success Rate')).toHaveText('0%');
+    await expect(statValue(page, 'Current Streak')).toHaveText('0');
+  });
+
+  test('flips a day from completed to failed', async ({ page }) => {
+    await positiveBtn(page).click();
+    await expect(statValue(page, 'Success Rate')).toHaveText('100%');
+
+    await negativeBtn(page).click();
+    await expect(negativeBtn(page)).toHaveClass(/bg-red-500/);
+    await expect(positiveBtn(page)).not.toHaveClass(/bg-cyan-500/);
+    await expect(statValue(page, 'Success Rate')).toHaveText('0%');
+  });
+
+  test('saves a note and shows the calendar note indicator', async ({ page }) => {
+    await noteBox(page).fill('Felt great today');
+    await expect(noteBox(page)).toHaveValue('Felt great today');
+    await expect(page.locator(`[data-date="${TODAY}"] .bg-blue-400`)).toBeVisible();
+  });
+});

--- a/e2e/habits.spec.ts
+++ b/e2e/habits.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from '@playwright/test';
+import { gotoApp, positiveBtn, negativeBtn, statValue, habitName, openHabitMenu } from './helpers';
+
+const createHabit = async (page: import('@playwright/test').Page, name: string) => {
+  await openHabitMenu(page);
+  await page.locator('.habit-selector-new-btn').click();
+  await page.locator('.habit-selector-new-input').fill(name);
+  await page.getByRole('button', { name: 'Create', exact: true }).click();
+  await expect(habitName(page)).toHaveValue(name);
+};
+
+test.describe('habits', () => {
+  test.beforeEach(async ({ page }) => {
+    await gotoApp(page);
+  });
+
+  test('creates a new habit and makes it active', async ({ page }) => {
+    await createHabit(page, 'Reading');
+
+    await openHabitMenu(page);
+    await expect(page.locator('.habit-selector-item')).toHaveCount(2);
+  });
+
+  test('keeps each habit\'s logs separate', async ({ page }) => {
+    // Complete today on the default habit.
+    await positiveBtn(page).click();
+    await expect(statValue(page, 'Success Rate')).toHaveText('100%');
+
+    // A brand-new habit starts empty.
+    await createHabit(page, 'Meditation');
+    await expect(statValue(page, 'Success Rate')).toHaveText('0%');
+    await expect(positiveBtn(page)).not.toHaveClass(/bg-cyan-500/);
+
+    // Switching back restores the original habit's data.
+    await openHabitMenu(page);
+    await page.locator('.habit-selector-item', { hasText: 'Daily Habit' }).click();
+    await expect(habitName(page)).toHaveValue('Daily Habit');
+    await expect(statValue(page, 'Success Rate')).toHaveText('100%');
+  });
+
+  test('deletes a habit after confirmation', async ({ page }) => {
+    page.on('dialog', (d) => d.accept());
+    await createHabit(page, 'Reading');
+
+    await openHabitMenu(page);
+    await expect(page.locator('.habit-selector-item')).toHaveCount(2);
+
+    await page
+      .locator('.habit-selector-item', { hasText: 'Daily Habit' })
+      .locator('.habit-selector-delete')
+      .click();
+
+    await expect(page.locator('.habit-selector-item')).toHaveCount(1);
+    await expect(habitName(page)).toHaveValue('Reading');
+  });
+
+  test('offers no delete control for the last remaining habit', async ({ page }) => {
+    await openHabitMenu(page);
+    await expect(page.locator('.habit-selector-item')).toHaveCount(1);
+    await expect(page.locator('.habit-selector-delete')).toHaveCount(0);
+  });
+
+  test('applies custom labels to the daily action buttons', async ({ page }) => {
+    await openHabitMenu(page);
+    await page.getByPlaceholder('✕').fill('N');
+    await page.getByPlaceholder('✓').fill('Y');
+
+    // Labels apply live; the menu overlay doesn't affect the button text.
+    await expect(negativeBtn(page)).toHaveText('N');
+    await expect(positiveBtn(page)).toHaveText('Y');
+  });
+});

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,0 +1,40 @@
+import { expect, type Page } from '@playwright/test';
+
+// A fixed "today" so calendar layout and streak math are deterministic across
+// runs. 2025-06-16 is a Monday; the 15th is the day before, both in June 2025.
+export const FIXED_NOW = new Date('2025-06-16T10:00:00');
+export const TODAY = '2025-06-16';
+export const YESTERDAY = '2025-06-15';
+
+/** Load the app with a frozen clock and no onboarding toast, ready to drive. */
+export async function gotoApp(page: Page, now: Date = FIXED_NOW): Promise<void> {
+  await page.clock.setFixedTime(now);
+  // Suppress the first-run onboarding toast so it never overlaps controls.
+  await page.addInitScript(() => {
+    localStorage.setItem('habit-tracker-onboarding-dismissed', 'true');
+  });
+  await page.goto('/');
+  // The app auto-creates a "Daily Habit" on first load.
+  await expect(habitName(page)).toHaveValue('Daily Habit');
+}
+
+// --- Daily action ---
+export const positiveBtn = (page: Page) => page.locator('.daily-action-positive-btn');
+export const negativeBtn = (page: Page) => page.locator('.daily-action-negative-btn');
+export const noteBox = (page: Page) => page.locator('.daily-action-note');
+
+// --- Header ---
+export const habitName = (page: Page) => page.locator('.habit-header-name');
+
+// Value of the stat card with the given caption, e.g. statValue(page, 'Current Streak').
+export const statValue = (page: Page, name: string) =>
+  page
+    .locator('.bg-white', { has: page.locator('.stat-card-name', { hasText: name }) })
+    .locator('.stat-card-value');
+
+// --- Calendar ---
+export const dayCell = (page: Page, date: string) => page.locator(`[data-date="${date}"]`);
+export const dayCircle = (page: Page, date: string) => dayCell(page, date).locator('div').first();
+
+// --- Habit selector ---
+export const openHabitMenu = (page: Page) => page.locator('.habit-selector-trigger').click();

--- a/e2e/persistence.spec.ts
+++ b/e2e/persistence.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test';
+import { gotoApp, positiveBtn, noteBox, statValue, dayCircle, habitName, TODAY } from './helpers';
+
+test.describe('persistence', () => {
+  test('data survives a page reload', async ({ page }) => {
+    await gotoApp(page);
+
+    await positiveBtn(page).click();
+    await noteBox(page).fill('kept across reload');
+    await expect(statValue(page, 'Success Rate')).toHaveText('100%');
+
+    await page.reload();
+
+    await expect(habitName(page)).toHaveValue('Daily Habit');
+    await expect(statValue(page, 'Success Rate')).toHaveText('100%');
+    await expect(dayCircle(page, TODAY)).toHaveClass(/bg-cyan-500/);
+    await expect(noteBox(page)).toHaveValue('kept across reload');
+  });
+});

--- a/e2e/stats.spec.ts
+++ b/e2e/stats.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test';
+import { gotoApp, positiveBtn, negativeBtn, statValue, dayCell, TODAY, YESTERDAY } from './helpers';
+
+test.describe('stats', () => {
+  test.beforeEach(async ({ page }) => {
+    await gotoApp(page);
+  });
+
+  test('current streak counts consecutive completed days ending today', async ({ page }) => {
+    await positiveBtn(page).click();
+    await expect(statValue(page, 'Current Streak')).toHaveText('1');
+
+    // Also complete yesterday -> streak of 2.
+    await dayCell(page, YESTERDAY).click();
+    await expect(page.getByRole('heading', { name: /June 15/ })).toBeVisible();
+    await positiveBtn(page).click();
+    await expect(statValue(page, 'Current Streak')).toHaveText('2');
+  });
+
+  test('a failed today breaks the streak but keeps earlier completions in the rate', async ({ page }) => {
+    // Yesterday completed...
+    await dayCell(page, YESTERDAY).click();
+    await positiveBtn(page).click();
+
+    // ...today failed.
+    await dayCell(page, TODAY).click();
+    await expect(page.getByRole('heading', { name: 'Today' })).toBeVisible();
+    await negativeBtn(page).click();
+
+    await expect(statValue(page, 'Current Streak')).toHaveText('0');
+    // 1 completed of 2 tracked days.
+    await expect(statValue(page, 'Success Rate')).toHaveText('50%');
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "vue": "^3.5.39"
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
         "@types/node": "^24.13.2",
         "@vitejs/plugin-vue": "^6.0.7",
         "@vitest/coverage-v8": "^4.1.9",
@@ -1832,6 +1833,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -6086,6 +6103,53 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "dev": "vite",
     "build": "vue-tsc -b && vite build",
     "preview": "vite preview",
-    "test": "vitest --run --coverage"
+    "test": "vitest --run --coverage",
+    "e2e": "playwright test",
+    "e2e:ui": "playwright test --ui",
+    "e2e:report": "playwright show-report"
   },
   "dependencies": {
     "@tailwindcss/postcss": "^4.3.2",
@@ -20,6 +23,7 @@
     "vue": "^3.5.39"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "@types/node": "^24.13.2",
     "@vitejs/plugin-vue": "^6.0.7",
     "@vitest/coverage-v8": "^4.1.9",
@@ -28,8 +32,8 @@
     "happy-dom": "^20.10.6",
     "typescript": "~5.9.3",
     "vite": "npm:rolldown-vite@^7.2.9",
+    "vite-plugin-pwa": "^1.3.0",
     "vitest": "^4.1.9",
-    "vue-tsc": "^3.3.6",
-    "vite-plugin-pwa": "^1.3.0"
+    "vue-tsc": "^3.3.6"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const PORT = 5173;
+const baseURL = `http://localhost:${PORT}`;
+
+// End-to-end tests run against a real browser driving the built app served by
+// Vite. Unit tests (Vitest) live under src/**/*.test.ts; these e2e specs live
+// under e2e/**/*.spec.ts so the two runners never pick up each other's files.
+export default defineConfig({
+  testDir: './e2e',
+  testMatch: '**/*.spec.ts',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [['html', { open: 'never' }], ['list']] : 'list',
+
+  use: {
+    baseURL,
+    // The app is mobile-first (max-w-md); test at a phone-ish viewport.
+    viewport: { width: 390, height: 844 },
+    trace: 'on-first-retry',
+  },
+
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'], viewport: { width: 390, height: 844 } } },
+  ],
+
+  // Vite dev is a clean target for e2e: vite-plugin-pwa keeps the service worker
+  // off in dev, so there is no cache to make tests flaky. strictPort makes a port
+  // clash fail loudly instead of silently serving on another port.
+  webServer: {
+    command: `npm run dev -- --port ${PORT} --strictPort`,
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/src/components/Calendar.vue
+++ b/src/components/Calendar.vue
@@ -108,9 +108,10 @@ const getDayClasses = (day: Date | null, index: number) => {
         :class="getDayClasses(day, index)"
       >
         <template v-if="day">
-          <div 
+          <div
             class="relative w-full h-full flex flex-col items-center justify-center"
             :class="isClickable(day) ? 'cursor-pointer' : 'cursor-default'"
+            :data-date="toDateKey(day)"
             @click="handleDateClick(day)"
           >
             <div 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -34,6 +34,9 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'happy-dom',
+    // Unit tests only. End-to-end specs live in e2e/**/*.spec.ts and are run by
+    // Playwright, not Vitest.
+    include: ['src/**/*.test.ts'],
     coverage: {
       reporter: ['json-summary'],
       provider: 'v8',


### PR DESCRIPTION
## Summary

Adds an in-browser end-to-end test suite (Playwright, Chromium) covering the app's core user flows, plus CI wiring. Independent of the unit tests — nothing about the existing Vitest setup changes.

## What's covered (11 specs)
- **daily-action** — mark a day complete/failed, toggle-off to clear, save a note + calendar note indicator
- **calendar** — today highlight, completed-day color, future-day guard, month navigation
- **stats** — current streak across consecutive days, streak-break + success-rate math
- **habits** — create / switch / delete (handling the `confirm` dialog), per-habit data isolation, last-habit delete guard, custom labels
- **persistence** — state survives a page reload

## How it works
- `playwright.config.ts` starts the app via the Vite **dev** server (the PWA service worker is off in dev, so there's no cache to make tests flaky) on a strict port; Chromium at a phone viewport (390×844).
- A **frozen clock** (fixed "today") makes calendar layout and streak assertions deterministic across runs.
- Each test gets a fresh browser context → clean `localStorage`; a small init script suppresses the first-run onboarding toast.

## Test-runner separation
- Unit tests stay `src/**/*.test.ts` (Vitest); e2e are `e2e/**/*.spec.ts` (Playwright).
- Vitest is pinned via `test.include: ['src/**/*.test.ts']` so it never runs the e2e specs. `npm run test` is unchanged.

## CI
- New **independent** `e2e` job in `build-and-deploy.yaml` (PR + push to main): `npm ci` → `npx playwright install --with-deps chromium` → `npm run e2e`, uploading the HTML report artifact. Does not gate the Pages deploy.

## App change
- One non-behavioral tweak: a `data-date` attribute on Calendar day cells so date selection is selectable from tests.

## Scripts
`npm run e2e`, `npm run e2e:ui`, `npm run e2e:report`.

## Verification
- e2e: **16 passed** (Chromium, headless, ~2.4s)
- unit: **131 passed (18 files)** — unchanged, confirming runner isolation
- `npm run build` (vue-tsc + Vite + PWA): green

🤖 Generated with [Claude Code](https://claude.com/claude-code)