### PR TITLE
ci: bump build/deploy job actions to current majors

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -26,7 +26,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -44,15 +44,15 @@ jobs:
       - name: build app
         run: npm run build
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           # Upload entire repository
           path: './dist/'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 
   # End-to-end tests run in a real browser against the Vite dev server, which
   # Playwright starts and stops itself (see playwright.config.ts). Runs


### PR DESCRIPTION
## Summary

Bumps the pre-existing `build`/deploy job's GitHub Actions to their current major versions. Follow-up to #190, which flagged that the e2e job used stale versions — this brings the older build/deploy job in line too.

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | **v7** |
| `actions/configure-pages` | v5 | **v6** |
| `actions/upload-pages-artifact` | v3 | **v5** |
| `actions/deploy-pages` | v4 | **v5** |

Versions verified as the latest published releases via the GitHub API. No action inputs change. The three Pages actions are bumped together so the uploaded artifact stays compatible across `upload-pages-artifact` → `deploy-pages`.

Not touched: `jpb06/coverage-badges-action@latest` (third-party, intentionally floating).

After this, every action pin in the workflow is current (the e2e job already uses checkout v7 / setup-node v6 / upload-artifact v7 from #190).

🤖 Generated with [Claude Code](https://claude.com/claude-code)